### PR TITLE
Fix unexpected behavior with optional values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,12 @@
 
 ..
 
-  There's no such thing as Sanity Clause.
+  You can't fool me. There ain't no santy clause!
 
-  -- Groucho Marx
+  -- Chico Marx
 
 
-Sanity clause is a data validation/contract library.  You might use it for configuration data, validating an api response, or documents from a datastore.  In a dynamically typed langauge, it helps you define clearly defined areas of doubt and uncertainty.  We should love our users, but we should never blindly trust their inputs.
+Sanity clause is a data validation/contract library.  You might use it for configuration data, validating an api response, or documents from a datastore.  In a dynamically typed language, it helps you define clearly defined areas of doubt and uncertainty.  We should love our users, but we should never blindly trust their inputs.
 
 To make use of it, you define schemas, which can be property lists with symbols for keys and instances of :class:`sanity-clause.field:field` subclasses that dictate the type of values you expect as well as the shape of the property list to be returned after deserializing and validating data.  For example::
 
@@ -32,7 +32,7 @@ You can load these sorts of schemas from a file by writing them as sexps with ke
   (:key (:string :validator (:not-empty) :default "potato")
    :key2 (:integer :validator ((:int :min 0)) :default 2))
 
-and then loading them using :function:`sanity-clause.loadable-schema:load` to load them.
+and then loading them using :function:`sanity-clause.loadable-schema:load-schema` to load them.
 
 
 Finally, you can also define class-based schemas using :class:`sanity-clause:validated-metaclass` like::
@@ -51,7 +51,7 @@ Finally, you can also define class-based schemas using :class:`sanity-clause:val
                  :required t))
         (:metaclass sanity-clause:validated-metaclass))
 
-which will validate thier initargs when you instantiate them (**BUT NOT WHEN YOU SET SLOTS**).  Hopefully, that will be added eventually, perhaps as an optional feature.
+which will validate their initargs when you instantiate them (**BUT NOT WHEN YOU SET SLOTS**).  Hopefully, that will be added eventually, perhaps as an optional feature.
 
 
 ~~~~~~~

--- a/docs/default.css
+++ b/docs/default.css
@@ -210,8 +210,11 @@ pre.address {
     font-size: 100% }
 
 pre.literal-block, pre.doctest-block {
-    margin-left: 2em ;
-    margin-right: 2em }
+    font-family: 'Fira Mono', monospace;
+    padding: 1em 2em;
+    background: #eee;
+    border-radius: 4px;
+    overflow-x: auto; }
 
 span.classifier {
     font-family: sans-serif ;
@@ -279,11 +282,12 @@ ul.auto-toc {
 
 /* Begin coo customization */
 
-@import url("//fonts.googleapis.com/css?family=Fira+Mono|Fira+Sans");
+@import url("//fonts.googleapis.com/css?family=Fira+Mono|Fira+Sans&display=swap");
 
 :root {
     font-family: "Fira Sans", sans-serif;
     font-size: 16px;
+    line-height: 1.5em;
 }
 
 .document {
@@ -295,55 +299,56 @@ span.pre {
     font-family: "Fira Mono", monospace;
 }
 
+
 h2 {
     background: #eee;
-    border-width: 1px 0;
+    border-width: 1px 0 0;
     border-color: black;
     border-style: solid;
+    padding: 1em 0 0.5em 1em;
+    letter-spacing: 2px;
+}
+
+tt {
+    font-family: "Fira Mono", monospace;
 }
 
 .ref-package {
-    font-family: "Fira Mono", mono;
-    background-color: #eee;
+    font-family: 'Fira Mono', monospace;
     color: #ab7967;
     padding: 3px;
-    border-radius: 6px;
+    border-radius: 4px;
 }
 
 .ref-class {
-    font-family: "Fira Mono", mono;
-    background-color: #eee;
+    font-family: 'Fira Mono', monospace;
     color: #99c794;
     padding: 3px;
-    border-radius: 6px;
+    border-radius: 4px;
 }
 
 .ref-variable {
-    font-family: "Fira Mono", mono;
-    background-color: #eee;
+    font-family: 'Fira Mono', monospace;
     color: #6699cc;
     padding: 3px;
-    border-radius: 6px;
+    border-radius: 4px;
 }
 
 .ref-macro {
-    font-family: "Fira Mono", mono;
-    background-color: #eee;
+    font-family: 'Fira Mono', monospace;
     color: #fac863;
     padding: 3px;
-    border-radius: 6px;
+    border-radius: 4px;
 }
 
 .ref-function {
-    font-family: "Fira Mono", mono;
-    background-color: #eee;
+    font-family: 'Fira Mono', monospace;
     color: #c594c5;
     padding: 3px;
-    border-radius: 6px;
+    border-radius: 4px;
 }
 
 .param {
-    background-color: #eee;
     color: #6699cc;
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,11 +7,11 @@
 <meta name="Author" content="Matt Novenstern" />
 </head>
 <body>
-<div id="id1" class="document"><h1 class="title">sanity-clause</h1>
+<div id="sanity-clause" class="document"><h1 class="title">sanity-clause</h1>
 <table class="docinfo" frame="void" rules="none"><col class="docinfo-name" />
 <col class="docinfo-content" />
 <tbody valign="top">
-<tr><th class="docinfo-name">Author</th><td>Matt Novenstern</td></tr><tr><th class="docinfo-name">Version</th><td>0.5.0</td></tr><tr class="field"><th colspan="1" class="docinfo-name">license:</th><td class="field-body">LLGPLv3+</td>
+<tr><th class="docinfo-name">Author</th><td>Matt Novenstern</td></tr><tr><th class="docinfo-name">Version</th><td>0.6.0</td></tr><tr class="field"><th colspan="1" class="docinfo-name">license:</th><td class="field-body">LLGPLv3+</td>
 </tr>
 <tr class="field"><th colspan="1" class="docinfo-name">homepage:</th><td class="field-body"><a class="reference" href="https://fisxoj.github.io/sanity-clause/"><span>https://fisxoj.github.io/sanity-clause/</span></a></td>
 </tr>
@@ -19,6 +19,7 @@
 </table>
 <div class="image image-reference"><a class="reference" href="https://travis-ci.org/fisxoj/sanity-clause"><span><img src="https://travis-ci.org/fisxoj/sanity-clause.svg?branch=master" alt="Travis CI status badge" /></span></a></div>
 <div class="image image-reference"><a class="reference" href="https://coveralls.io/github/fisxoj/sanity-clause?branch=master"><span><img src="https://coveralls.io/repos/github/fisxoj/sanity-clause/badge.svg?branch=master" alt="Coveralls status badge" /></span></a></div>
+<div class="image image-reference"><a class="reference" href="CODE_OF_CONDUCT.md"><span><img src="https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg" alt="Contributor Covenant" /></span></a></div>
 <table class="field-list" frame="void" rules="none"><col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
@@ -29,9 +30,9 @@
 </tbody>
 </table>
 <!--  -->
-<blockquote> <p>There's no such thing as Sanity Clause.</p>
-<p class="attribution">&mdash; Groucho Marx  </p>
-</blockquote> <p>Sanity clause is a data validation/contract library.  You might use it for configuration data, validating an api response, or documents from a datastore.  In a dynamically typed langauge, it helps you define clearly defined areas of doubt and uncertainty.  We should love our users, but we should never blindly trust their inputs.</p>
+<blockquote> <p>You can't fool me. There ain't no santy clause!</p>
+<p class="attribution">&mdash; Chico Marx  </p>
+</blockquote> <p>Sanity clause is a data validation/contract library.  You might use it for configuration data, validating an api response, or documents from a datastore.  In a dynamically typed language, it helps you define clearly defined areas of doubt and uncertainty.  We should love our users, but we should never blindly trust their inputs.</p>
 <p>To make use of it, you define schemas, which can be property lists with symbols for keys and instances of <a class="reference ref-class" href="sanity-clause.field.html#class__field"><span class="ref-class">sanity-clause.field:field</span></a> subclasses that dictate the type of values you expect as well as the shape of the property list to be returned after deserializing and validating data.  For example:</p>
 <pre class="literal-block">
 (list :name (make-field :string) :age (make-field :integer))
@@ -41,7 +42,7 @@ schema.sexp
 
 (:key (:string :validator (:not-empty) :default "potato")
  :key2 (:integer :validator ((:int :min 0)) :default 2))
-</pre><p>and then loading them using <a class="reference ref-function" href="http://www.lispworks.com/reference/HyperSpec/Body/f_load.htm"><span class="ref-function">common-lisp:load</span></a> to load them.</p>
+</pre><p>and then loading them using <a class="reference ref-function" href="sanity-clause.loadable-schema.html#function__load-schema"><span class="ref-function">sanity-clause.loadable-schema:load-schema</span></a> to load them.</p>
 <p>Finally, you can also define class-based schemas using <a class="reference ref-class" href="sanity-clause.schema.html#class__validated-metaclass"><span class="ref-class">sanity-clause.schema:validated-metaclass</span></a> like:</p>
 <pre class="literal-block">
 (defclass person ()
@@ -57,7 +58,7 @@ schema.sexp
               :initarg :potato
               :required t))
      (:metaclass sanity-clause:validated-metaclass))
-</pre><p>which will validate thier initargs when you instantiate them (<strong><span>BUT NOT WHEN YOU SET SLOTS</span></strong>).  Hopefully, that will be added eventually, perhaps as an optional feature.</p>
+</pre><p>which will validate their initargs when you instantiate them (<strong><span>BUT NOT WHEN YOU SET SLOTS</span></strong>).  Hopefully, that will be added eventually, perhaps as an optional feature.</p>
 <div id="example" class="section"><h2><a name="example">Example</a></h2>
 <p><tt class="docutils literal">
 <span class="pre">v2-info.json</span></tt>:</p>
@@ -155,8 +156,8 @@ schema.sexp
 ;; =&gt; "Apache 2.0"
 
 
-</pre><div class="section"><p class="sidebar-title first">Packages</p>
-<ul class="last">
+</pre><div id="packages" class="section"><h3><a name="packages">Packages</a></h3>
+<ul>
 <li><p class="first last"><a class="reference" href="sanity-clause.util.html"><span>sanity-clause.util</span></a></p>
 </li>
 <li><p class="first last"><a class="reference" href="sanity-clause.validator.html"><span>sanity-clause.validator</span></a></p>
@@ -165,16 +166,10 @@ schema.sexp
 </li>
 <li><p class="first last"><a class="reference" href="sanity-clause.field.html"><span>sanity-clause.field</span></a></p>
 </li>
-<li><p class="first last"><a class="reference" href="sanity-clause.loadable-schema.html"><span>sanity-clause.loadable-schema</span></a></p>
-</li>
-<li><p class="first last"><a class="reference" href="sanity-clause.schema.html"><span>sanity-clause.schema</span></a></p>
-</li>
-<li><p class="first last"><a class="reference" href="sanity-clause.html"><span>sanity-clause</span></a></p>
-</li>
 </ul>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Sat, 10 Aug 2019 19:19:54 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
 </div>
 </div>
 </body>

--- a/docs/sanity-clause.field.html
+++ b/docs/sanity-clause.field.html
@@ -55,6 +55,9 @@
 </tbody>
 </table>
 <p>A field type that allows any of the schemas specified.</p>
+<p>Use the <tt class="docutils literal">
+<span class="pre">:schema-choices</span></tt> initarg to provide a list of schema classes to try.</p>
+<p><strong><span>Note</span></strong>: If your schema choices are very lenient (ie. every field is not required), this field will likely behave in unexpected ways.  That is, if you specify a list of classes that only have optional fields, sanity clause won't be able to figure out which one to use and will probably return the missing value instead of valid data.  You probably want at least one charactersitic field to be required.</p>
 <a id="class-one-field-of-field" class="target" name="class-one-field-of-field"></a></div>
 <div id="one-field-of-field" class="section"><h3><a name="one-field-of-field"><tt class="docutils literal">
 <span class="pre">one-field-of-field</span></tt></a></h3>
@@ -95,19 +98,6 @@
 </tbody>
 </table>
 <p>An error that signals a required value is missing.</p>
-<a id="condition-conversion-error" class="target" name="condition-conversion-error"></a></div>
-<div id="conversion-error" class="section"><h3><a name="conversion-error"><tt class="docutils literal">
-<span class="pre">conversion-error</span></tt></a></h3>
-<table class="field-list" frame="void" rules="none"><col class="field-name" />
-<col class="field-body" />
-<tbody valign="top">
-<tr class="field"><th colspan="1" class="field-name">Superclasses:</th><td class="field-body"><tt class="docutils literal">
-<span class="pre">(FIELD-ERROR</span> <span class="pre">VALUE-ERROR)</span></tt></td>
-</tr>
-</tbody>
-</table>
-<p>An error that signals something went wrong while calling <tt class="docutils literal">
-<span class="pre">converter</span></tt> for a field.</p>
 <a id="condition-validation-error" class="target" name="condition-validation-error"></a></div>
 <div id="validation-error" class="section"><h3><a name="validation-error"><tt class="docutils literal">
 <span class="pre">validation-error</span></tt></a></h3>
@@ -246,7 +236,7 @@
 <p>A base class for all fields that controls how they are (de?)serialized.</p>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Sat, 10 Aug 2019 19:19:54 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
 </div>
 </div>
 </body>

--- a/docs/sanity-clause.protocol.html
+++ b/docs/sanity-clause.protocol.html
@@ -12,8 +12,26 @@
 <span class="pre">sanity-clause.protocol</span></tt> package</h1>
 <p><a class="reference" href="index.html"><span>&lt;&lt; back to sanity-clause index</span></a></p>
 <p>The methods that govern behavior in sanity-clause.</p>
-<p>The methods relating to fields are: * <a class="reference ref-function" href="sanity-clause.protocol.html#function__resolve"><span class="ref-function">resolve</span></a> * <a class="reference ref-function" href="sanity-clause.protocol.html#function__deserialize"><span class="ref-function">deserialize</span></a> * <a class="reference ref-function" href="sanity-clause.protocol.html#function__serialize"><span class="ref-function">serialize</span></a> * <a class="reference ref-function" href="sanity-clause.protocol.html#function__validate"><span class="ref-function">validate</span></a> * <a class="reference ref-function" href="sanity-clause.protocol.html#function__get-value"><span class="ref-function">get-value</span></a></p>
-<p>The methods relating to schemas are: * <a class="reference ref-function" href="sanity-clause.protocol.html#function__load"><span class="ref-function">load</span></a> * <a class="reference ref-function" href="sanity-clause.protocol.html#function__dump"><span class="ref-function">dump</span></a></p>
+<p>The methods relating to fields are:</p>
+<ul>
+<li><p class="first last"><a class="reference ref-function" href="sanity-clause.protocol.html#function__resolve"><span class="ref-function">resolve</span></a></p>
+</li>
+<li><p class="first last"><a class="reference ref-function" href="sanity-clause.protocol.html#function__deserialize"><span class="ref-function">deserialize</span></a></p>
+</li>
+<li><p class="first last"><a class="reference ref-function" href="sanity-clause.protocol.html#function__serialize"><span class="ref-function">serialize</span></a></p>
+</li>
+<li><p class="first last"><a class="reference ref-function" href="sanity-clause.protocol.html#function__validate"><span class="ref-function">validate</span></a></p>
+</li>
+<li><p class="first last"><a class="reference ref-function" href="sanity-clause.protocol.html#function__get-value"><span class="ref-function">get-value</span></a></p>
+</li>
+</ul>
+<p>The methods relating to schemas are:</p>
+<ul>
+<li><p class="first last"><a class="reference ref-function" href="sanity-clause.protocol.html#function__load"><span class="ref-function">load</span></a></p>
+</li>
+<li><p class="first last"><a class="reference ref-function" href="sanity-clause.protocol.html#function__dump"><span class="ref-function">dump</span></a></p>
+</li>
+</ul>
 <p>Exported symbols:</p>
 <div id="generic-functions" class="section"><h2><a name="generic-functions">Generic Functions</a></h2>
 <a id="generic-function-dump" class="target" name="generic-function-dump"></a><div id="dump" class="section"><h3><a name="dump"><tt class="docutils literal">
@@ -68,7 +86,7 @@
 <p>A function that encapsulates getting, corecing, and validating values for a field.  Calls <a class="reference ref-function" href="sanity-clause.protocol.html#function__get-value"><span class="ref-function">get-value</span></a>, <a class="reference ref-function" href="sanity-clause.protocol.html#function__deserialize"><span class="ref-function">deserialize</span></a>, and <a class="reference ref-function" href="sanity-clause.protocol.html#function__validate"><span class="ref-function">validate</span></a>.</p>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Sat, 10 Aug 2019 19:19:54 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
 </div>
 </div>
 </body>

--- a/docs/sanity-clause.util.html
+++ b/docs/sanity-clause.util.html
@@ -29,7 +29,7 @@
 <span class="pre">((KEY</span> <span class="pre">VALUE)</span> <span class="pre">DATA</span> <span class="pre">&amp;BODY</span> <span class="pre">BODY)</span></tt></p>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Sat, 10 Aug 2019 19:19:54 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
 </div>
 </div>
 </body>

--- a/docs/sanity-clause.validator.html
+++ b/docs/sanity-clause.validator.html
@@ -36,13 +36,23 @@
 <span class="pre">str</span></tt></a></h3>
 <p><tt class="docutils literal">
 <span class="pre">(VALUE</span> <span class="pre">&amp;KEY</span> <span class="pre">MIN-LENGTH</span> <span class="pre">MAX-LENGTH)</span></tt></p>
-<p>Checks that the input is a string, optionally of a length between MIN-LENGTH and MAX-LENGTH.</p>
+<p>Checks that <tt class="docutils literal param">
+<span class="pre">value</span></tt> is a string. If specified, checks that <tt class="docutils literal param">
+<span class="pre">min-length</span></tt> &lt;= <tt class="docutils literal">
+<span class="pre">(length</span> <span class="pre">value)</span></tt> &lt;= <tt class="docutils literal param">
+<span class="pre">max-length</span></tt>.</p>
 <a id="function-int" class="target" name="function-int"></a></div>
 <div id="int" class="section"><h3><a name="int"><tt class="docutils literal">
 <span class="pre">int</span></tt></a></h3>
 <p><tt class="docutils literal">
-<span class="pre">(VALUE</span> <span class="pre">&amp;KEY</span> <span class="pre">MAX</span> <span class="pre">MIN)</span></tt></p>
-<p>Checks that a number is an integer, optionally checking it's in the inclusive range [MIN, MAX].</p>
+<span class="pre">(VALUE</span> <span class="pre">&amp;KEY</span> <span class="pre">(RADIX</span> <span class="pre">10)</span> <span class="pre">MAX</span> <span class="pre">MIN)</span></tt></p>
+<p>Accepts a <tt class="docutils literal param">
+<span class="pre">value</span></tt> as an integer or string. If <tt class="docutils literal param">
+<span class="pre">value</span></tt> is a string, interpret it as a value with base- <tt class="docutils literal param">
+<span class="pre">radix</span></tt>. If specified, make sure <tt class="docutils literal param">
+<span class="pre">min</span></tt> &lt;= <tt class="docutils literal param">
+<span class="pre">value</span></tt> &lt;= <tt class="docutils literal param">
+<span class="pre">max</span></tt>.</p>
 <a id="function-hydrate-validators" class="target" name="function-hydrate-validators"></a></div>
 <div id="hydrate-validators" class="section"><h3><a name="hydrate-validators"><tt class="docutils literal">
 <span class="pre">hydrate-validators</span></tt></a></h3>
@@ -57,7 +67,7 @@
 <p>Find a validator function by keyword-spec and return the function represented by the spec.</p>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Sat, 10 Aug 2019 19:19:54 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
 </div>
 </div>
 </body>

--- a/sanity-clause.asd
+++ b/sanity-clause.asd
@@ -1,7 +1,7 @@
 (defsystem sanity-clause
   :author "Matt Novenstern"
-  :version "0.5.1"
   :license "LGPLv3+"
+  :version "0.6.0"
   :homepage "https://fisxoj.github.io/sanity-clause/"
   :depends-on ("alexandria"
                "cl-arrows"

--- a/sanity-clause.asd
+++ b/sanity-clause.asd
@@ -1,7 +1,7 @@
 (defsystem sanity-clause
   :author "Matt Novenstern"
-  :license "LLGPLv3+"
   :version "0.5.1"
+  :license "LGPLv3+"
   :homepage "https://fisxoj.github.io/sanity-clause/"
   :depends-on ("alexandria"
                "cl-arrows"

--- a/src/field.lisp
+++ b/src/field.lisp
@@ -51,7 +51,7 @@ Also contains :function:`sanity-clause.protocol:get-value`, :function:`sanity-cl
 
 
 (deftype missing ()
-  :missing)
+  '(eql :missing))
 
 
 (defclass field ()
@@ -86,6 +86,11 @@ Also contains :function:`sanity-clause.protocol:get-value`, :function:`sanity-cl
 	     :documentation "Is this field required?  Cause the field to fail validation if it's not filled."))
   (:documentation "A base class for all fields that controls how they are (de?)serialized."))
 
+
+(defmethod print-object ((object field) stream)
+  (print-unreadable-object (object stream :type t :identity t)
+    (format stream "~@[data-key: ~a~]" (data-key-of object))))
+
 ;;; The most generic forms of these methods are defined here
 (defun all-validators (field)
   "Returns a generator function that yields a validator function each call."
@@ -109,13 +114,15 @@ Also contains :function:`sanity-clause.protocol:get-value`, :function:`sanity-cl
 (defmethod sanity-clause.protocol:resolve ((field field) data &optional parents)
   (declare (ignore parents))
 
-  (let ((value (->> data
-                    (sanity-clause.protocol:get-value field)
-                    (sanity-clause.protocol:deserialize field))))
+  (let ((value (sanity-clause.protocol:get-value field data)))
 
-    (sanity-clause.protocol:validate field value)
+    (if (eq value :missing)
+        value
+        (let ((deserialized-value (sanity-clause.protocol:deserialize field value)))
 
-    (values value)))
+          (sanity-clause.protocol:validate field deserialized-value)
+
+          (values deserialized-value)))))
 
 
 (defmethod sanity-clause.protocol:deserialize :around ((field field) value)
@@ -409,11 +416,16 @@ Also contains :function:`sanity-clause.protocol:get-value`, :function:`sanity-cl
 
 
 (defmethod sanity-clause.protocol:deserialize ((field nested-field) value)
-  (sanity-clause.protocol:load (element-type-of field) value))
+  (if (eq value :missing)
+      value
+      (sanity-clause.protocol:load (element-type-of field) value)))
 
 
 (defmethod sanity-clause.protocol:deserialize ((field list-field) value)
   (etypecase value
+    (missing
+     value)
+
     (trivial-types:proper-list
      (with-slots (element-type) field
        (mapcar (lambda (item) (sanity-clause.protocol:load element-type item)) value)))))
@@ -460,6 +472,7 @@ examples::
              (etypecase field-args-or-field
                ((or symbol cons)
                 (apply #'make-field (make-args field-args-or-field)))
+
                (field
                 ;; The sub-field needs the same data-key as the parent to get the data
                 ;; might as well set attribute, too

--- a/src/field.lisp
+++ b/src/field.lisp
@@ -515,7 +515,11 @@ examples::
                    :accessor schema-choices-of
                    :documentation "Fields that this field could decode to."
                    :initform (error ":schema-choices is required in one-schema-of-field.")))
-  (:documentation "A field type that allows any of the schemas specified."))
+  (:documentation "A field type that allows any of the schemas specified.
+
+Use the ``:schema-choices`` initarg to provide a list of schema classes to try.
+
+**Note**: If your schema choices are very lenient (ie. every field is not required), this field will likely behave in unexpected ways.  That is, if you specify a list of classes that only have optional fields, sanity clause won't be able to figure out which one to use and will probably return the missing value instead of valid data.  You probably want at least one charactersitic field to be required."))
 
 
 (defmethod initialize-instance :after ((field one-schema-of-field) &key)

--- a/src/field.lisp
+++ b/src/field.lisp
@@ -439,8 +439,8 @@ examples::
   (let (accumulator)
     (with-slots (key-field value-field) field
       (sanity-clause.util:do-key-values (k v) data
-        (push (cons (resolve key-field k (list* key-field parents))
-                    (resolve value-field v (list* value-field parents)))
+        (push (cons (sanity-clause.protocol:resolve key-field k (list* key-field parents))
+                    (sanity-clause.protocol:resolve value-field v (list* value-field parents)))
               accumulator)))
     accumulator))
 

--- a/src/protocol.lisp
+++ b/src/protocol.lisp
@@ -11,6 +11,7 @@
   (:documentation "The methods that govern behavior in sanity-clause.
 
 The methods relating to fields are:
+
 * :function:`resolve`
 * :function:`deserialize`
 * :function:`serialize`
@@ -18,6 +19,7 @@ The methods relating to fields are:
 * :function:`get-value`
 
 The methods relating to schemas are:
+
 * :function:`load`
 * :function:`dump`"))
 

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -153,7 +153,7 @@ In the event the type isn't a simple type, assume it's a class with metaclass :c
                    (sanity-clause.field:data-key-of field))
 
           (appendf validated-initargs
-                   (list initarg (sanity-clause:resolve (field-of slot) data-source))))))
+                   (list initarg (sanity-clause.protocol:resolve (field-of slot) data-source))))))
 
     (apply #'call-next-method class validated-initargs)))
 

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -225,10 +225,9 @@ In the event the type isn't a simple type, assume it's a class with metaclass :c
 
 
 (defun collect-initargs-from-list (class data)
-  "Converts an input list from form ``([data-key] [value] ...)`` or ``(([data-key] . [value]) ...)`` to ``([initarg] [value] ...)`` so it is suitable for passing to :function:`make-instance`."
+  "Converts input data that is an alist, plist, object, or hash-table to ``([initarg] [value] ...)`` so it is suitable for passing to :function:`make-instance`.  Note that, while it tries to be very lenient about case and symbol/string comparison, implementation details (like the test function for a hash table) will affect the behavior of this function."
 
-  (declare (type validated-metaclass class)
-           (type (or trivial-types:property-list trivial-types:association-list) data))
+  (declare (type validated-metaclass class))
 
   (c2mop:ensure-finalized class)
 

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -152,14 +152,8 @@ In the event the type isn't a simple type, assume it's a class with metaclass :c
                    ;; Don't bother trying to load something we don't have a data-key for
                    (sanity-clause.field:data-key-of field))
 
-          (let ((value (->>
-                        (sanity-clause.util:get-value data-source initarg (sanity-clause.field::default-of (field-of slot)))
-                        (sanity-clause.protocol:deserialize field))))
-
-            (sanity-clause.protocol:validate field value)
-
-            (appendf validated-initargs
-                     (list initarg value))))))
+          (appendf validated-initargs
+                   (list initarg (sanity-clause:resolve (field-of slot) data-source))))))
 
     (apply #'call-next-method class validated-initargs)))
 

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -41,7 +41,11 @@
 
 	 (let* ((assoc-cons (assoc key object :test #'string-equal))
 		(value (or (cdr assoc-cons) default)))
-	   (values value (not (null assoc-cons))))))))
+	   (values value (not (null assoc-cons)))))
+
+        (hash-table
+
+         (gethash key object default)))))
 
 
 (defmacro do-key-values ((key value) data &body body)

--- a/t/field.lisp
+++ b/t/field.lisp
@@ -238,8 +238,7 @@ E.g. (let ((string-field (make-field 'string))
   (defclass human ()
     ((name :type string
            :initarg :name)
-     (cat-friend :type cat
-                 :field-type :nested
+     (cat-friend :field-type :nested
                  :element-type cat
                  :initarg :cat-friend))
     (:metaclass sanity-clause:validated-metaclass))
@@ -248,8 +247,7 @@ E.g. (let ((string-field (make-field 'string))
   (defclass human-with-cat-list ()
     ((name :type string
            :initarg :name)
-     (cat-friends :type cat
-                  :field-type :list
+     (cat-friends :field-type :list
                   :element-type cat
                   :initarg :cat-friends))
     (:metaclass sanity-clause:validated-metaclass))

--- a/t/field.lisp
+++ b/t/field.lisp
@@ -229,7 +229,7 @@ E.g. (let ((string-field (make-field 'string))
 
 
 (deftest test-one-field-of-field
-  (testing "a one-of-field defined with field classes"
+  (testing "a one-of-field defined with :field-choices class syntax"
     (let* ((string-field (make-field :string :validator 'sanity-clause.validator:not-empty))
            (integer-field (make-field :integer))
            (field (sanity-clause:make-field :one-field-of :data-key :data :field-choices (list string-field integer-field))))
@@ -243,7 +243,7 @@ E.g. (let ((string-field (make-field 'string))
       (ok (signals (sanity-clause.protocol:resolve field (list :data (local-time:now))) 'sanity-clause.field:conversion-error)
           "signals an error for a datetime.")))
 
-  (testing "a one-of-field defined with keyword syntax"
+  (testing "a one-of-field defined with :field-choices keyword syntax"
     (let ((field (sanity-clause:make-field :one-field-of :data-key :data :field-choices '((:string :validator (:not-empty)) :integer))))
 
       (ok (typep (sanity-clause.protocol:resolve field '(:data "hello")) 'string)

--- a/t/field.lisp
+++ b/t/field.lisp
@@ -204,7 +204,7 @@ E.g. (let ((string-field (make-field 'string))
 
 
 (deftest test-missing-values
-  (defclass pizza ()
+  (defclass t-m-v-pizza ()
     ((type :field-type :member
            :initarg :type
            :members (:pepperoni :hawaiian :plain)
@@ -217,13 +217,13 @@ E.g. (let ((string-field (make-field 'string))
              :validator (lambda (rating) (sanity-clause.validator:int rating :min 0 :max 5))))
     (:metaclass sanity-clause:validated-metaclass))
 
-  (ok (signals (make-instance 'pizza
+  (ok (signals (make-instance 't-m-v-pizza
                               :size :small)
           'required-value-error)
       "A required field signals an error when it's not supplied.")
 
 
-  (ok (eq (slot-value (make-instance 'pizza :type :plain) 'rating) :missing)
+  (ok (eq (slot-value (make-instance 't-m-v-pizza :type :plain) 'rating) :missing)
       "The :missing sentinel gets used for non-required field"))
 
 
@@ -285,26 +285,57 @@ E.g. (let ((string-field (make-field 'string))
 (deftest test-one-schema-of-field
   (testing "A one-schema-of-field with two options"
 
-    (defclass pizza ()
+    (defclass tosof-pizza ()
       ((name :initarg :name
-             :type string))
+             :type string
+             :required t))
       (:metaclass sanity-clause.schema:validated-metaclass))
 
-    (defclass weasel-count ()
+    (defclass tosof-weasel-count ()
       ((count :initarg :count
               :type integer
-              :validate (lambda (v) (sanity-clause.validator:int v :min 0))))
+              :validate (lambda (v) (sanity-clause.validator:int v :min 0))
+              :required t))
       (:metaclass sanity-clause.schema:validated-metaclass))
 
-    (let ((dumb-field (sanity-clause.field:make-field :one-schema-of :schema-choices '(pizza weasel-count))))
-      (ok (typep (sanity-clause.protocol:resolve dumb-field '(:name "pepperoni")) 'pizza)
+    (let ((dumb-field (sanity-clause.field:make-field :one-schema-of :schema-choices '(tosof-pizza tosof-weasel-count) :required t)))
+      (ok (typep (sanity-clause.protocol:resolve dumb-field '(:name "pepperoni")) 'tosof-pizza)
           "decodes the first option.")
 
-      (ok (typep (sanity-clause.protocol:resolve dumb-field '(:count "112")) 'weasel-count)
+      (ok (typep (sanity-clause.protocol:resolve dumb-field '(:count "112")) 'tosof-weasel-count)
           "decodes the second option.")
 
       (ok (signals (sanity-clause.protocol:resolve dumb-field '(:armadillo :arnie)) 'sanity-clause.field:conversion-error)
-          "signals an error if it can't decode either option."))))
+          "signals an error if it can't decode either option.")))
+
+  (testing "a descriminated union based on a 'version' field)"
+    (defclass tosof-v1 ()
+      ((version :field-type :constant
+                :initarg :version
+                :constant "1"
+                :required t))
+      (:metaclass sanity-clause:validated-metaclass))
+
+    (defclass tosof-v2 ()
+      ((version :field-type :constant
+                :initarg :version
+                :constant "2"
+                :required t))
+      (:metaclass sanity-clause:validated-metaclass))
+
+    (defclass tosof-v3 ()
+      ((version :field-type :constant
+                :initarg :version
+                :constant "3"
+                :required t))
+      (:metaclass sanity-clause:validated-metaclass))
+
+    (let ((union-type-field (make-field :one-schema-of :schema-choices '(tosof-v1 tosof-v2 tosof-v3))))
+      (ok (every 'eq
+                 '(tosof-v3 tosof-v1 tosof-v2)
+                 (mapcar (lambda (data) (class-name (class-of (sanity-clause:resolve union-type-field data))))
+                         '((:version "3") (:version "1") (:version "2"))))
+          "decodes to the correct version of the class."))))
 
 
 (deftest test-one-field-of-field

--- a/t/schema.lisp
+++ b/t/schema.lisp
@@ -52,7 +52,54 @@
 
       (ok (signals (sanity-clause.protocol:load plist-schema '(:name "Matt"))
               'required-value-error)
-          "A missing, required value raises a required value error."))))
+          "A missing, required value raises a required value error.")))
+
+  (testing "alists"
+    (let ((schema (list :name (make-field 'string)
+                        :age  (make-field 'integer :required t))))
+
+      (ok (sanity-clause.protocol:load schema '((:name . "Matt") (:age . 30)))
+	  "Can load from valid data.")
+
+      (ok (sanity-clause.protocol:load schema '((:name . "Matt") (:age . "30")))
+	  "Can load valid data, converting from a string, if necessary.")
+
+      (ok (signals (sanity-clause.protocol:load schema '((:name . "Matt") (:age .  "potato")))
+              'conversion-error)
+          "A string that isn't an int raises a conversion error.")
+
+      (ok (signals (sanity-clause.protocol:load schema '((:name . 11) (:age . 30)))
+              'conversion-error)
+          "An integer that is not a string raises a validation error.")
+
+      (ok (signals (sanity-clause.protocol:load schema '((:name . "Matt")))
+              'required-value-error)
+          "A missing, required value raises a required value error.")))
+
+  (testing "hash-tables"
+    (flet ((make-test-hash (alist)
+             (alexandria:alist-hash-table alist :test 'equal)))
+
+      (let ((schema (list :name (make-field 'string)
+                          :age  (make-field 'integer :required t))))
+
+        (ok (sanity-clause.protocol:load schema (make-test-hash '((:name . "Matt") (:age . 30))))
+            "Can load from valid data.")
+
+        (ok (sanity-clause.protocol:load schema (make-test-hash '((:name . "Matt") (:age . "30"))))
+            "Can load valid data, converting from a string, if necessary.")
+
+        (ok (signals (sanity-clause.protocol:load schema (make-test-hash '((:name . "Matt") (:age .  "potato"))))
+                'conversion-error)
+            "A string that isn't an int raises a conversion error.")
+
+        (ok (signals (sanity-clause.protocol:load schema (make-test-hash '((:name . 11) (:age . 30))))
+                'conversion-error)
+            "An integer that is not a string raises a validation error.")
+
+        (ok (signals (sanity-clause.protocol:load schema (make-test-hash '((:name . "Matt"))))
+                'required-value-error)
+            "A missing, required value raises a required value error.")))))
 
 
 (deftest test-examples


### PR DESCRIPTION
* Adds docs for one-schema-of behavior with classes with all optional slots
* Adds hash-table access to `s-c.utils:get-value`
* Makes optional slots not raise errors when missing value doesn't pass `decode` or `validate`

Closes #18 