### PR TITLE
Bugfix/nested class protocol

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@
 
 Sanity clause is a data validation/contract library.  You might use it for configuration data, validating an api response, or documents from a datastore.  In a dynamically typed language, it helps you define clearly defined areas of doubt and uncertainty.  We should love our users, but we should never blindly trust their inputs.
 
-To make use of it, you define schemas, which can be property lists with symbols for keys and instances of :class:`sanity-clause.field:field` subclasses that dictate the type of values you expect as well as the shape of the property list to be returned after deserializing and validating data.  For example::
+To make use of it, you define schemas, which can be property lists with keys and instances of :class:`sanity-clause.field:field` subclasses as values (eg. :class:`sanity-clause.field:integer-field`, :class:`sanity-clause.field:string-field`, &c.) or using the class-based interface via :class:`sanity-clause.schema:validated-metaclass`.  For example::
 
    (list :name (make-field :string) :age (make-field :integer))
 
@@ -35,19 +35,16 @@ You can load these sorts of schemas from a file by writing them as sexps with ke
 and then loading them using :function:`sanity-clause.loadable-schema:load-schema` to load them.
 
 
-Finally, you can also define class-based schemas using :class:`sanity-clause:validated-metaclass` like::
+To use class-based schemas using :class:`sanity-clause:validated-metaclass` you can do things like::
 
    (defclass person ()
         ((favorite-dog :type symbol
                        :field-type :member
                        :members (:wedge :walter)
-                       :initarg :favorite-dog
                        :required t)
          (age :type (integer 0)
-              :initarg :age
               :required t)
          (potato :type string
-                 :initarg :potato
                  :required t))
         (:metaclass sanity-clause:validated-metaclass))
 
@@ -84,26 +81,21 @@ Example
 
   (defclass contact-object ()
     ((name :type string
-           :initarg :name
            :documentation "The identifying name of the contact person/organization.")
      (url :type string
           :field-type :uri
-          :initarg :url
           :documentation "The URL pointing to the contact information. MUST be in the format of a URL.")
      (email :type string
             :field-type :email
-            :initarg :email
             :documentation "The email address of the contact person/organization. MUST be in the format of an email address."))
     (:metaclass sanity-clause:validated-metaclass))
 
 
   (defclass license-object ()
     ((name :type string
-           :initarg :name
            :documentation "The license name used for the API.")
      (url :type string
           :field-type :uri
-          :initarg :url
           :documentation "A URL to the license used for the API. MUST be in the format of a URL."))
     (:metaclass sanity-clause:validated-metaclass))
 
@@ -111,28 +103,22 @@ Example
   (defclass info-object ()
     ((title :type string
             :data-key "title"
-            :initarg :title
             :required t
             :documentation "The title of the application.")
      (description :type string
-                  :initarg :description
                   :documentation "A short description of the application. GFM syntax can be used for rich text representation.")
      (terms-of-service :type string
                        :data-key "termsOfService"
-                       :initarg :terms-of-service
                        :documentation "The Terms of Service for the API.")
      (contact :type contact-object
               :field-type :nested
               :element-type contact-object
-              :initarg :contact
               :documentation "The contact information for the exposed API.")
      (license :type license-object
               :field-type :nested
               :element-type license-object
-              :initarg :license
               :documentation "The license information for the exposed API.")
      (version :type string
-              :initarg :version
               :documentation "Provides the version of the application API (not to be confused with the specification version)."
               :required t))
     (:metaclass sanity-clause:validated-metaclass))

--- a/docs/default.css
+++ b/docs/default.css
@@ -210,11 +210,8 @@ pre.address {
     font-size: 100% }
 
 pre.literal-block, pre.doctest-block {
-    font-family: 'Fira Mono', monospace;
-    padding: 1em 2em;
-    background: #eee;
-    border-radius: 4px;
-    overflow-x: auto; }
+    margin-left: 2em ;
+    margin-right: 2em }
 
 span.classifier {
     font-family: sans-serif ;
@@ -282,12 +279,11 @@ ul.auto-toc {
 
 /* Begin coo customization */
 
-@import url("//fonts.googleapis.com/css?family=Fira+Mono|Fira+Sans&display=swap");
+@import url("//fonts.googleapis.com/css?family=Fira+Mono|Fira+Sans");
 
 :root {
     font-family: "Fira Sans", sans-serif;
     font-size: 16px;
-    line-height: 1.5em;
 }
 
 .document {
@@ -299,56 +295,55 @@ span.pre {
     font-family: "Fira Mono", monospace;
 }
 
-
 h2 {
     background: #eee;
-    border-width: 1px 0 0;
+    border-width: 1px 0;
     border-color: black;
     border-style: solid;
-    padding: 1em 0 0.5em 1em;
-    letter-spacing: 2px;
-}
-
-tt {
-    font-family: "Fira Mono", monospace;
 }
 
 .ref-package {
-    font-family: 'Fira Mono', monospace;
+    font-family: "Fira Mono", mono;
+    background-color: #eee;
     color: #ab7967;
     padding: 3px;
-    border-radius: 4px;
+    border-radius: 6px;
 }
 
 .ref-class {
-    font-family: 'Fira Mono', monospace;
+    font-family: "Fira Mono", mono;
+    background-color: #eee;
     color: #99c794;
     padding: 3px;
-    border-radius: 4px;
+    border-radius: 6px;
 }
 
 .ref-variable {
-    font-family: 'Fira Mono', monospace;
+    font-family: "Fira Mono", mono;
+    background-color: #eee;
     color: #6699cc;
     padding: 3px;
-    border-radius: 4px;
+    border-radius: 6px;
 }
 
 .ref-macro {
-    font-family: 'Fira Mono', monospace;
+    font-family: "Fira Mono", mono;
+    background-color: #eee;
     color: #fac863;
     padding: 3px;
-    border-radius: 4px;
+    border-radius: 6px;
 }
 
 .ref-function {
-    font-family: 'Fira Mono', monospace;
+    font-family: "Fira Mono", mono;
+    background-color: #eee;
     color: #c594c5;
     padding: 3px;
-    border-radius: 4px;
+    border-radius: 6px;
 }
 
 .param {
+    background-color: #eee;
     color: #6699cc;
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
 <table class="docinfo" frame="void" rules="none"><col class="docinfo-name" />
 <col class="docinfo-content" />
 <tbody valign="top">
-<tr><th class="docinfo-name">Author</th><td>Matt Novenstern</td></tr><tr><th class="docinfo-name">Version</th><td>0.6.0</td></tr><tr class="field"><th colspan="1" class="docinfo-name">license:</th><td class="field-body">LLGPLv3+</td>
+<tr><th class="docinfo-name">Author</th><td>Matt Novenstern</td></tr><tr><th class="docinfo-name">Version</th><td>0.7.0</td></tr><tr class="field"><th colspan="1" class="docinfo-name">license:</th><td class="field-body">LGPLv3</td>
 </tr>
 <tr class="field"><th colspan="1" class="docinfo-name">homepage:</th><td class="field-body"><a class="reference" href="https://fisxoj.github.io/sanity-clause/"><span>https://fisxoj.github.io/sanity-clause/</span></a></td>
 </tr>
@@ -33,7 +33,7 @@
 <blockquote> <p>You can't fool me. There ain't no santy clause!</p>
 <p class="attribution">&mdash; Chico Marx  </p>
 </blockquote> <p>Sanity clause is a data validation/contract library.  You might use it for configuration data, validating an api response, or documents from a datastore.  In a dynamically typed language, it helps you define clearly defined areas of doubt and uncertainty.  We should love our users, but we should never blindly trust their inputs.</p>
-<p>To make use of it, you define schemas, which can be property lists with symbols for keys and instances of <a class="reference ref-class" href="sanity-clause.field.html#class__field"><span class="ref-class">sanity-clause.field:field</span></a> subclasses that dictate the type of values you expect as well as the shape of the property list to be returned after deserializing and validating data.  For example:</p>
+<p>To make use of it, you define schemas, which can be property lists with keys and instances of <a class="reference ref-class" href="sanity-clause.field.html#class__field"><span class="ref-class">sanity-clause.field:field</span></a> subclasses as values (eg. <a class="reference ref-class" href="sanity-clause.field.html#class__integer-field"><span class="ref-class">sanity-clause.field:integer-field</span></a>, <a class="reference ref-class" href="sanity-clause.field.html#class__string-field"><span class="ref-class">sanity-clause.field:string-field</span></a>, &amp;c.) or using the class-based interface via <a class="reference ref-class" href="sanity-clause.schema.html#class__validated-metaclass"><span class="ref-class">sanity-clause.schema:validated-metaclass</span></a>.  For example:</p>
 <pre class="literal-block">
 (list :name (make-field :string) :age (make-field :integer))
 </pre><p>You can load these sorts of schemas from a file by writing them as sexps with keywords, like this:</p>
@@ -43,19 +43,16 @@ schema.sexp
 (:key (:string :validator (:not-empty) :default "potato")
  :key2 (:integer :validator ((:int :min 0)) :default 2))
 </pre><p>and then loading them using <a class="reference ref-function" href="sanity-clause.loadable-schema.html#function__load-schema"><span class="ref-function">sanity-clause.loadable-schema:load-schema</span></a> to load them.</p>
-<p>Finally, you can also define class-based schemas using <a class="reference ref-class" href="sanity-clause.schema.html#class__validated-metaclass"><span class="ref-class">sanity-clause.schema:validated-metaclass</span></a> like:</p>
+<p>To use class-based schemas using <a class="reference ref-class" href="sanity-clause.schema.html#class__validated-metaclass"><span class="ref-class">sanity-clause.schema:validated-metaclass</span></a> you can do things like:</p>
 <pre class="literal-block">
 (defclass person ()
      ((favorite-dog :type symbol
                     :field-type :member
                     :members (:wedge :walter)
-                    :initarg :favorite-dog
                     :required t)
       (age :type (integer 0)
-           :initarg :age
            :required t)
       (potato :type string
-              :initarg :potato
               :required t))
      (:metaclass sanity-clause:validated-metaclass))
 </pre><p>which will validate their initargs when you instantiate them (<strong><span>BUT NOT WHEN YOU SET SLOTS</span></strong>).  Hopefully, that will be added eventually, perhaps as an optional feature.</p>
@@ -87,26 +84,21 @@ schema.sexp
 
 (defclass contact-object ()
   ((name :type string
-         :initarg :name
          :documentation "The identifying name of the contact person/organization.")
    (url :type string
         :field-type :uri
-        :initarg :url
         :documentation "The URL pointing to the contact information. MUST be in the format of a URL.")
    (email :type string
           :field-type :email
-          :initarg :email
           :documentation "The email address of the contact person/organization. MUST be in the format of an email address."))
   (:metaclass sanity-clause:validated-metaclass))
 
 
 (defclass license-object ()
   ((name :type string
-         :initarg :name
          :documentation "The license name used for the API.")
    (url :type string
         :field-type :uri
-        :initarg :url
         :documentation "A URL to the license used for the API. MUST be in the format of a URL."))
   (:metaclass sanity-clause:validated-metaclass))
 
@@ -114,28 +106,22 @@ schema.sexp
 (defclass info-object ()
   ((title :type string
           :data-key "title"
-          :initarg :title
           :required t
           :documentation "The title of the application.")
    (description :type string
-                :initarg :description
                 :documentation "A short description of the application. GFM syntax can be used for rich text representation.")
    (terms-of-service :type string
                      :data-key "termsOfService"
-                     :initarg :terms-of-service
                      :documentation "The Terms of Service for the API.")
    (contact :type contact-object
             :field-type :nested
             :element-type contact-object
-            :initarg :contact
             :documentation "The contact information for the exposed API.")
    (license :type license-object
             :field-type :nested
             :element-type license-object
-            :initarg :license
             :documentation "The license information for the exposed API.")
    (version :type string
-            :initarg :version
             :documentation "Provides the version of the application API (not to be confused with the specification version)."
             :required t))
   (:metaclass sanity-clause:validated-metaclass))
@@ -169,7 +155,7 @@ schema.sexp
 </ul>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Sun, 03 Nov 2019 21:45:48 .
 </div>
 </div>
 </body>

--- a/docs/sanity-clause.field.html
+++ b/docs/sanity-clause.field.html
@@ -86,7 +86,31 @@
 (make-field :map :key-field :string :value-field :integer)
 (deserialize * '(("potato" . 4) ("chimp" . 11)))
 
-</pre><a id="condition-required-value-error" class="target" name="condition-required-value-error"></a></div>
+</pre><a id="class-nested-field" class="target" name="class-nested-field"></a></div>
+<div id="nested-field" class="section"><h3><a name="nested-field"><tt class="docutils literal">
+<span class="pre">nested-field</span></tt></a></h3>
+<table class="field-list" frame="void" rules="none"><col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field"><th colspan="1" class="field-name">Superclasses:</th><td class="field-body"><tt class="docutils literal">
+<span class="pre">(FIELD</span> <span class="pre">NESTED-ELEMENT)</span></tt></td>
+</tr>
+</tbody>
+</table>
+<p>A field that represents a complex object located at this slot.</p>
+<a id="class-list-field" class="target" name="class-list-field"></a></div>
+<div id="list-field" class="section"><h3><a name="list-field"><tt class="docutils literal">
+<span class="pre">list-field</span></tt></a></h3>
+<table class="field-list" frame="void" rules="none"><col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field"><th colspan="1" class="field-name">Superclasses:</th><td class="field-body"><tt class="docutils literal">
+<span class="pre">(FIELD</span> <span class="pre">NESTED-ELEMENT)</span></tt></td>
+</tr>
+</tbody>
+</table>
+<p>A field that contains a list of values satsified by another field.</p>
+<a id="condition-required-value-error" class="target" name="condition-required-value-error"></a></div>
 <div id="required-value-error" class="section"><h3><a name="required-value-error"><tt class="docutils literal">
 <span class="pre">required-value-error</span></tt></a></h3>
 <table class="field-list" frame="void" rules="none"><col class="field-name" />
@@ -236,7 +260,7 @@
 <p>A base class for all fields that controls how they are (de?)serialized.</p>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Sun, 03 Nov 2019 21:45:48 .
 </div>
 </div>
 </body>

--- a/docs/sanity-clause.protocol.html
+++ b/docs/sanity-clause.protocol.html
@@ -86,7 +86,7 @@
 <p>A function that encapsulates getting, corecing, and validating values for a field.  Calls <a class="reference ref-function" href="sanity-clause.protocol.html#function__get-value"><span class="ref-function">get-value</span></a>, <a class="reference ref-function" href="sanity-clause.protocol.html#function__deserialize"><span class="ref-function">deserialize</span></a>, and <a class="reference ref-function" href="sanity-clause.protocol.html#function__validate"><span class="ref-function">validate</span></a>.</p>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Sun, 03 Nov 2019 21:45:48 .
 </div>
 </div>
 </body>

--- a/docs/sanity-clause.util.html
+++ b/docs/sanity-clause.util.html
@@ -29,7 +29,7 @@
 <span class="pre">((KEY</span> <span class="pre">VALUE)</span> <span class="pre">DATA</span> <span class="pre">&amp;BODY</span> <span class="pre">BODY)</span></tt></p>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Sun, 03 Nov 2019 21:45:48 .
 </div>
 </div>
 </body>

--- a/docs/sanity-clause.validator.html
+++ b/docs/sanity-clause.validator.html
@@ -67,7 +67,7 @@
 <p>Find a validator function by keyword-spec and return the function represented by the spec.</p>
 </div>
 </div>
-<hr class ="docutils footer" /><div class="footer">Generated on : Thu, 24 Oct 2019 17:05:33 .
+<hr class ="docutils footer" /><div class="footer">Generated on : Sun, 03 Nov 2019 21:45:48 .
 </div>
 </div>
 </body>

--- a/sanity-clause.asd
+++ b/sanity-clause.asd
@@ -1,7 +1,7 @@
 (defsystem sanity-clause
   :author "Matt Novenstern"
-  :license "LGPLv3+"
-  :version "0.6.0"
+  :license "LGPLv3"
+  :version "0.7.0"
   :homepage "https://fisxoj.github.io/sanity-clause/"
   :depends-on ("alexandria"
                "cl-arrows"

--- a/src/field.lisp
+++ b/src/field.lisp
@@ -12,27 +12,22 @@
 	   #:make-field
 
 	   ;; Fields
-	   #:string-field
+	   #:constant-field
 	   #:email-field
-	   #:member-field
 	   #:integer-field
 	   #:real-field
-	   #:constant-field
+	   #:string-field
 	   #:timestamp-field
-           #:uri-field
-           #:boolean-field
 	   #:uuid-field
+           #:boolean-field
+           #:list-field
+           #:uri-field
 
            #:map-field
-           #:one-schema-of-field
+	   #:member-field
+           #:nested-field
            #:one-field-of-field
-
-           ;; Fields defined in nested-fields.lisp
-           ;; #:map-field
-           ;; #:list-field
-           ;; #:nested-field
-           ;; #:one-field-of-field
-           ;; #:one-schema-of-field
+           #:one-schema-of-field
 
 	   ;; Readers
 	   #:attribute-of

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -216,18 +216,6 @@ In the event the type isn't a simple type, assume it's a class with metaclass :c
   (sanity-clause.protocol:get-value (field-of slot) object))
 
 
-(defun collect-initargs-from-list (class data)
-  "Converts input data that is an alist, plist, object, or hash-table to ``([initarg] [value] ...)`` so it is suitable for passing to :function:`make-instance`.  Note that, while it tries to be very lenient about case and symbol/string comparison, implementation details (like the test function for a hash table) will affect the behavior of this function."
-
-  (declare (type validated-metaclass class))
-
-  (c2mop:ensure-finalized class)
-
-  (loop for slot in (c2mop:class-slots class)
-        when (sanity-clause.field:load-field-p (field-of slot))
-          collecting (first (c2mop:slot-definition-initargs slot))
-        collecting (sanity-clause.protocol:get-value slot data)))
-
 ;;; Implementations of the load method for lists or metaclasses
 
 (defmethod sanity-clause.protocol:load ((schema list) data &optional format)

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -252,7 +252,7 @@ In the event the type isn't a simple type, assume it's a class with metaclass :c
 (defmethod sanity-clause.protocol:load ((class validated-metaclass) data &optional format)
   (declare (ignore format))
 
-  (funcall #'make-instance class 'data data))
+  (make-instance class 'data data))
 
 
 ;;; Implementations of the dump method for lists or metaclasses

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -11,21 +11,27 @@
         ((favorite-dog :type symbol
                        :field-type :member
                        :members (:wedge :walter)
-                       :initarg :favorite-dog
+                       :data-key \"favoriteDog\"
                        :required t)
          (age :type (integer 0)
-              :initarg :age
+              :data-key \"age\"
               :required t)
          (potato :type string
-                 :initarg :potato
+                 :data-key \"potato\"
                  :required t))
         (:metaclass validated-metaclass))
 
-The above defines a class that can be instantiated with :function:`make-instance`, but will error if the initargs don't satisfy the contract required by the field.
+The above defines a class that can be instantiated with :function:`sanity-clause.protocol:load, but will error if the initargs don't satisfy the contract required by the field.
+
+::
+
+    (sanity-clause:load 'person '((\"favoriteDog\" . \"wedge\")
+                                  (\"age\" . 10)
+                                  (\"potato\" . \"weasel\"))
 
 Some special types can be specifed with lisp type specs, like ``age`` above, which will generate an :class:`sanity-clause.field:integer-field`, with validations requiring the value be at least 0.
 
-**Nota Bene:** At the moment, there is no validation done on updating slots after instances are created."))
+**Nota Bene:** At the moment, there is no validation done on updating slots after instances are created and only instances created with :function:`sanity-clause.protocol:load` are checked.  Using :function:`make-instance` doesn't validate anything."))
 
 (in-package :sanity-clause.schema)
 

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -257,7 +257,7 @@ In the event the type isn't a simple type, assume it's a class with metaclass :c
   (apply #'make-instance class (collect-initargs-from-list class data)))
 
 
-;;; Implementations of the dump method ofr lists or metaclasses
+;;; Implementations of the dump method for lists or metaclasses
 
 (defmethod sanity-clause.protocol:dump ((schema symbol) data &optional format)
   (sanity-clause.protocol:dump (find-class schema) data format))

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -150,8 +150,11 @@ In the event the type isn't a simple type, assume it's a class with metaclass :c
                    ;; Don't bother trying to load something we don't have a data-key for
                    (sanity-clause.field:data-key-of field))
 
-          (setf (c2mop:slot-value-using-class class instance slot)
-                (sanity-clause.protocol:resolve field data-source)))))
+          (let ((value (sanity-clause.protocol:resolve field data-source)))
+
+            (unless (eq value :missing)
+              (setf (c2mop:slot-value-using-class class instance slot)
+                    value))))))
 
     (values instance)))
 

--- a/t/field.lisp
+++ b/t/field.lisp
@@ -220,11 +220,11 @@ E.g. (let ((string-field (make-field 'string))
   (ok (signals (sanity-clause:load 't-m-v-pizza
                                    '(:size :small))
           'required-value-error)
-      "A required field signals an error when it's not supplied.")
+      "a required field signals an error when it's not supplied.")
 
 
-  (ok (eq (slot-value (sanity-clause:load 't-m-v-pizza '(:type :plain)) 'rating) :missing)
-      "The :missing sentinel gets used for non-required field"))
+  (ok (not (slot-boundp (sanity-clause:load 't-m-v-pizza '(:type :plain)) 'rating))
+      "non-required fields are left unbound if data isn't supplied."))
 
 
 (deftest test-nested-field
@@ -261,8 +261,8 @@ E.g. (let ((string-field (make-field 'string))
       (ok (typep (slot-value (sanity-clause:load 'human data-with-cat) 'cat-friend) 'cat)
           "deserializes a cat class also, when data exists.")
 
-      (ok (eq (slot-value (sanity-clause:load 'human data-without-cat) 'cat-friend) :missing)
-          "deserializes the default missing value, when data is missing.")))
+      (ok (not (slot-boundp (sanity-clause:load 'human data-without-cat) 'cat-friend))
+          "leaves a slot unbound, when data is missing and the slot isn't required.")))
 
   (testing "list nesting"
     (let ((data-with-cats '(:name "Matt" :cat-friends ((:name "Tara" :age 10) (:name "Tiger" :age 4))))
@@ -276,8 +276,8 @@ E.g. (let ((string-field (make-field 'string))
       (ok (zerop (length (slot-value (sanity-clause:load 'human-with-cat-list data-with-zero-cats) 'cat-friends)))
           "deserializes a list of zero cat classes, when fields exists but is empty.")
 
-      (ok (eq (slot-value (sanity-clause:load 'human-with-cat-list data-without-cats-field) 'cat-friends) :missing)
-          "deserializes the default missing value, when data is missing."))))
+      (ok (not (slot-boundp (sanity-clause:load 'human-with-cat-list data-without-cats-field) 'cat-friends))
+          "leaves a slot unbound, when data is missing and the slot isn't required."))))
 
 
 (deftest test-one-schema-of-field

--- a/t/field.lisp
+++ b/t/field.lisp
@@ -217,13 +217,13 @@ E.g. (let ((string-field (make-field 'string))
              :validator (lambda (rating) (sanity-clause.validator:int rating :min 0 :max 5))))
     (:metaclass sanity-clause:validated-metaclass))
 
-  (ok (signals (make-instance 't-m-v-pizza
-                              :size :small)
+  (ok (signals (sanity-clause:load 't-m-v-pizza
+                                   '(:size :small))
           'required-value-error)
       "A required field signals an error when it's not supplied.")
 
 
-  (ok (eq (slot-value (make-instance 't-m-v-pizza :type :plain) 'rating) :missing)
+  (ok (eq (slot-value (sanity-clause:load 't-m-v-pizza '(:type :plain)) 'rating) :missing)
       "The :missing sentinel gets used for non-required field"))
 
 

--- a/t/schema.lisp
+++ b/t/schema.lisp
@@ -217,7 +217,7 @@
         (:metaclass sanity-clause.schema:validated-metaclass))
       "can define the class.")
 
-  (ok (make-instance 'environment-sourced :source :env)
+  (ok (sanity-clause:load 'environment-sourced '(:source :env))
       "can load from the envrionment."))
 
 
@@ -238,7 +238,7 @@
             :initarg :pie))
       (:metaclass sanity-clause.schema:validated-metaclass))
 
-    (ok (signals (make-instance 'b :pie :apple) 'sanity-clause.field:conversion-error)
+    (ok (signals (sanity-clause:load 'b '(:pie :apple)) 'sanity-clause.field:conversion-error)
         "take the most specific definition of the field, raising an error for values that were valid for the old version.")
 
     (ok (make-instance 'b :pie "peach")
@@ -257,31 +257,33 @@
   (defclass pie-inventory ()
     ((pie :field-type :nested
           :element-type pie
+          :data-key :pie
           :initarg :pie)
      (quantity :type integer
-               :initarg :qty))
+               :data-key :qty))
     (:metaclass sanity-clause.schema:validated-metaclass))
 
   (defclass pie-list ()
     ((pies :type list
            :field-type :list
            :element-type pie
-           :initarg :pies))
+           :initarg :pies
+           :data-key :pies))
     (:metaclass sanity-clause.schema:validated-metaclass))
 
 
   (testing "pie inventory"
-    (let ((inventory (make-instance 'pie-inventory :pie '(:pie "peach") :qty 10)))
+    (let ((inventory (sanity-clause:load 'pie-inventory '(:pie (:pie "peach") :qty 10))))
 
       (ok (typep (slot-value inventory 'pie) 'pie)
           "Pie slot is an instance of pie class.")
 
       (ok (typep (slot-value inventory 'quantity) 'integer)
-          "Qunantity slot is an instance of integer.")))
+          "Quantity slot is an instance of integer.")))
 
 
   (testing "list of pies"
-    (let ((pie-list (make-instance 'pie-list :pies '((:pie "peach") (:pie "peach") (:pie "key-lime")))))
+    (let ((pie-list (sanity-clause:load 'pie-list '(:pies ((:pie "peach") (:pie "peach") (:pie "key-lime"))))))
 
       (ok pie-list
           "Can create a nested class with pies in it.")


### PR DESCRIPTION
Nested classes have been broken, apparently.  This work changes the instance creation protocol to require using `sanity-clause:load` for enforcing contracts, though you can still make classes with `make-instance`.

- [x] Update docs
- [x] New tests for nested fields
- [x] Change missing value behavior to unbound slot rather than trying to set `:missing` as the value.  This will make things more type-safe when a slot is expected to be a certain type.